### PR TITLE
feat: add configurable local data directory with stale lock recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifeq ($(GOOS),windows)
 endif
 
 # Install directory (defaults to ~/go/bin, override with INSTALL_DIR=path)
-INSTALL_DIR ?= $(HOME)/go/bin
+INSTALL_DIR ?= $(GOPATH)/bin
 
 .PHONY: all build test test-short test-coverage lint fmt fmt-check clean docker-build docker-push tools run help deps install
 
@@ -46,6 +46,9 @@ build: deps ## Build the cie binary
 install: build ## Install cie binary globally (default: ~/go/bin, override: INSTALL_DIR=path)
 	@mkdir -p $(INSTALL_DIR)
 	@cp bin/cie $(INSTALL_DIR)/cie
+ifeq ($(GOOS),darwin)
+	@codesign --force --sign - $(INSTALL_DIR)/cie
+endif
 	@echo "✓ Installed cie to $(INSTALL_DIR)/cie"
 
 deps: ## Download dependencies (CozoDB)

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ When running as an MCP server, CIE provides 20+ tools organized by category:
 
 ## Data Storage
 
-CIE stores indexed data locally in `~/.cie/data/<project_id>/` using embedded CozoDB with RocksDB backend. This ensures:
+CIE stores indexed data locally in `<local_data_dir>/<project_id>/` (default: `~/.cie/data/<project_id>/`) using embedded CozoDB with RocksDB backend. This ensures:
 
 - Your code never leaves your machine
 - Fast local queries
@@ -294,7 +294,7 @@ CIE uses an embedded architecture -- a single binary handles indexing, querying,
 │  │  - cie index  → Parses code, writes to local CozoDB  │    │
 │  │  - cie --mcp  → Reads from local CozoDB              │    │
 │  │                                                       │    │
-│  │  Data: ~/.cie/data/<project>/  (RocksDB)             │    │
+│  │  Data: <local_data_dir>/<project>/ (RocksDB)         │    │
 │  └──────────────────────────────────────────────────────┘    │
 │                                                               │
 │  ┌──────────────┐  (optional)                                │
@@ -307,7 +307,7 @@ CIE uses an embedded architecture -- a single binary handles indexing, querying,
 **Key Components:**
 
 - **CIE CLI**: Single binary handles indexing, querying, and MCP serving
-- **CozoDB + RocksDB**: Embedded database stored locally at `~/.cie/data/<project>/`
+- **CozoDB + RocksDB**: Embedded database stored locally at `<local_data_dir>/<project>` (default `~/.cie/data/<project>`)
 - **Ollama (optional)**: Local embedding generation for semantic search
 - **Tree-sitter**: Code parsing for Go, Python, JS, TS
 

--- a/cmd/cie/config.go
+++ b/cmd/cie/config.go
@@ -61,10 +61,11 @@ type EmbeddingConfig struct {
 
 // IndexingConfig contains indexing settings.
 type IndexingConfig struct {
-	ParserMode  string   `yaml:"parser_mode"`   // auto, treesitter
-	BatchTarget int      `yaml:"batch_target"`  // mutations per batch
-	MaxFileSize int64    `yaml:"max_file_size"` // bytes
-	Exclude     []string `yaml:"exclude"`       // glob patterns
+	ParserMode   string   `yaml:"parser_mode"`              // auto, treesitter
+	BatchTarget  int      `yaml:"batch_target"`             // mutations per batch
+	MaxFileSize  int64    `yaml:"max_file_size"`            // bytes
+	Exclude      []string `yaml:"exclude"`                  // glob patterns
+	LocalDataDir string   `yaml:"local_data_dir,omitempty"` // custom data root (project dir appended)
 }
 
 // RolesConfig contains custom role pattern definitions.
@@ -346,6 +347,9 @@ func (c *Config) applyEnvOverrides() {
 	}
 	if model := os.Getenv("OLLAMA_EMBED_MODEL"); model != "" {
 		c.Embedding.Model = model
+	}
+	if dataDir := os.Getenv("CIE_DATA_DIR"); dataDir != "" {
+		c.Indexing.LocalDataDir = dataDir
 	}
 }
 

--- a/cmd/cie/config_cmd.go
+++ b/cmd/cie/config_cmd.go
@@ -59,10 +59,11 @@ type EmbeddingOutput struct {
 
 // IndexingOutput represents indexing settings for JSON output.
 type IndexingOutput struct {
-	ParserMode  string   `json:"parser_mode"`
-	BatchTarget int      `json:"batch_target"`
-	MaxFileSize int64    `json:"max_file_size"`
-	Exclude     []string `json:"exclude"`
+	ParserMode   string   `json:"parser_mode"`
+	BatchTarget  int      `json:"batch_target"`
+	MaxFileSize  int64    `json:"max_file_size"`
+	Exclude      []string `json:"exclude"`
+	LocalDataDir string   `json:"local_data_dir,omitempty"`
 }
 
 // RolesConfigOutput represents custom role patterns for JSON output.
@@ -243,10 +244,11 @@ func buildConfigOutput(configPath string, cfg *Config) *ConfigOutput {
 			Model:    cfg.Embedding.Model,
 		},
 		Indexing: IndexingOutput{
-			ParserMode:  cfg.Indexing.ParserMode,
-			BatchTarget: cfg.Indexing.BatchTarget,
-			MaxFileSize: cfg.Indexing.MaxFileSize,
-			Exclude:     cfg.Indexing.Exclude,
+			ParserMode:   cfg.Indexing.ParserMode,
+			BatchTarget:  cfg.Indexing.BatchTarget,
+			MaxFileSize:  cfg.Indexing.MaxFileSize,
+			Exclude:      cfg.Indexing.Exclude,
+			LocalDataDir: cfg.Indexing.LocalDataDir,
 		},
 	}
 
@@ -298,6 +300,9 @@ func printConfigHuman(cfg *ConfigOutput) {
 	fmt.Printf("  Parser Mode:  %s\n", cfg.Indexing.ParserMode)
 	fmt.Printf("  Batch Target: %d\n", cfg.Indexing.BatchTarget)
 	fmt.Printf("  Max File:     %d bytes\n", cfg.Indexing.MaxFileSize)
+	if cfg.Indexing.LocalDataDir != "" {
+		fmt.Printf("  Data Dir:     %s\n", cfg.Indexing.LocalDataDir)
+	}
 	if len(cfg.Indexing.Exclude) > 0 {
 		fmt.Printf("  Exclude:      %d patterns\n", len(cfg.Indexing.Exclude))
 		for _, pattern := range cfg.Indexing.Exclude {

--- a/cmd/cie/doc.go
+++ b/cmd/cie/doc.go
@@ -121,7 +121,7 @@
 //
 // Indexed data is stored locally in:
 //
-//	~/.cie/data/<project_id>/
+//	<configured_data_dir>/<project_id>/ (default: ~/.cie/data/<project_id>/)
 //
 // This includes RocksDB databases for local storage and CozoDB for
 // Datalog-based queries. Use the reset command to clear local data.

--- a/cmd/cie/main.go
+++ b/cmd/cie/main.go
@@ -159,7 +159,8 @@ Getting Started:
   4. Run MCP server:            cie --mcp
 
 Data Storage:
-  Data is stored locally in ~/.cie/data/<project_id>/
+  Data is stored locally in the configured data directory
+  (default: ~/.cie/data/<project_id>/)
 
 Environment Variables:
   OLLAMA_HOST        Ollama URL (default: http://localhost:11434)

--- a/cmd/cie/paths.go
+++ b/cmd/cie/paths.go
@@ -1,0 +1,93 @@
+// Copyright 2025 KrakLabs
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kraklabs/cie/internal/errors"
+)
+
+// dataRootFromConfig resolves the storage root with precedence:
+// CIE_DATA_DIR > indexing.local_data_dir > ~/.cie/data.
+func dataRootFromConfig(cfg *Config, configPath string) (string, error) {
+	if envDir := os.Getenv("CIE_DATA_DIR"); envDir != "" {
+		return absPath(envDir)
+	}
+
+	if cfg != nil && cfg.Indexing.LocalDataDir != "" {
+		custom := cfg.Indexing.LocalDataDir
+		if filepath.IsAbs(custom) {
+			return filepath.Clean(custom), nil
+		}
+
+		cfgFilePath, err := resolvedConfigPath(configPath)
+		if err == nil {
+			baseDir := filepath.Dir(cfgFilePath)
+			return filepath.Clean(filepath.Join(baseDir, custom)), nil
+		}
+
+		return absPath(custom)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.NewInternalError(
+			"Cannot determine home directory",
+			"Operating system did not provide user home directory path",
+			"Check your system configuration or set HOME environment variable",
+			err,
+		)
+	}
+	return filepath.Join(home, ".cie", "data"), nil
+}
+
+// projectDataDir resolves the effective per-project data directory.
+func projectDataDir(cfg *Config, configPath string) (string, error) {
+	root, err := dataRootFromConfig(cfg, configPath)
+	if err != nil {
+		return "", err
+	}
+	if cfg == nil || cfg.ProjectID == "" {
+		return root, nil
+	}
+	return filepath.Join(root, cfg.ProjectID), nil
+}
+
+// legacyDefaultProjectDataDir returns ~/.cie/data/<project_id> regardless of overrides.
+func legacyDefaultProjectDataDir(projectID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cie", "data", projectID), nil
+}
+
+func resolvedConfigPath(configPath string) (string, error) {
+	if configPath != "" {
+		return absPath(configPath)
+	}
+	if envPath := os.Getenv("CIE_CONFIG_PATH"); envPath != "" {
+		return absPath(envPath)
+	}
+	path, err := findConfigFile()
+	if err != nil {
+		return "", fmt.Errorf("resolve config path: %w", err)
+	}
+	return absPath(path)
+}
+
+func absPath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}

--- a/cmd/cie/paths_test.go
+++ b/cmd/cie/paths_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataRootFromConfig_Default(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CIE_DATA_DIR", "")
+
+	root, err := dataRootFromConfig(&Config{ProjectID: "demo"}, "")
+	if err != nil {
+		t.Fatalf("dataRootFromConfig() error = %v", err)
+	}
+
+	want := filepath.Join(home, ".cie", "data")
+	if root != want {
+		t.Fatalf("dataRootFromConfig() = %q, want %q", root, want)
+	}
+}
+
+func TestDataRootFromConfig_EnvOverride(t *testing.T) {
+	t.Setenv("CIE_DATA_DIR", "/tmp/custom-cie")
+
+	root, err := dataRootFromConfig(&Config{ProjectID: "demo"}, "")
+	if err != nil {
+		t.Fatalf("dataRootFromConfig() error = %v", err)
+	}
+	if root != "/tmp/custom-cie" {
+		t.Fatalf("dataRootFromConfig() = %q, want %q", root, "/tmp/custom-cie")
+	}
+}
+
+func TestDataRootFromConfig_RelativeLocalDataDir(t *testing.T) {
+	t.Setenv("CIE_DATA_DIR", "")
+
+	repo := t.TempDir()
+	cfg := &Config{
+		ProjectID: "demo",
+		Indexing: IndexingConfig{
+			LocalDataDir: "./.cie/db",
+		},
+	}
+
+	cfgPath := filepath.Join(repo, ".cie", "project.yaml")
+	root, err := dataRootFromConfig(cfg, cfgPath)
+	if err != nil {
+		t.Fatalf("dataRootFromConfig() error = %v", err)
+	}
+
+	want := filepath.Join(repo, ".cie", ".cie", "db")
+	if root != want {
+		t.Fatalf("dataRootFromConfig() = %q, want %q", root, want)
+	}
+}
+
+func TestProjectDataDir_AppendsProjectID(t *testing.T) {
+	t.Setenv("CIE_DATA_DIR", "/tmp/cie-root")
+
+	dir, err := projectDataDir(&Config{ProjectID: "my-project"}, "")
+	if err != nil {
+		t.Fatalf("projectDataDir() error = %v", err)
+	}
+	if dir != "/tmp/cie-root/my-project" {
+		t.Fatalf("projectDataDir() = %q, want %q", dir, "/tmp/cie-root/my-project")
+	}
+}

--- a/cmd/cie/query.go
+++ b/cmd/cie/query.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -143,16 +142,10 @@ Notes:
 	}
 
 	// Determine data directory
-	homeDir, err := os.UserHomeDir()
+	dataDir, err := projectDataDir(cfg, configPath)
 	if err != nil {
-		errors.FatalError(errors.NewInternalError(
-			"Cannot determine home directory",
-			"Operating system did not provide user home directory path",
-			"Check your system configuration or set HOME environment variable",
-			err,
-		), globals.JSON)
+		errors.FatalError(err, globals.JSON)
 	}
-	dataDir := filepath.Join(homeDir, ".cie", "data", cfg.ProjectID)
 
 	// Check if data directory exists
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {

--- a/cmd/cie/serve.go
+++ b/cmd/cie/serve.go
@@ -195,7 +195,8 @@ func runServe(args []string, cfg *Config) int {
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 		<-sigChan
-		log.Println("Shutting down CIE server...")
+		signal.Stop(sigChan)
+		log.Println("Shutting down CIE server... Press Ctrl+C again to force quit.")
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = server.Shutdown(ctx)

--- a/cmd/cie/status.go
+++ b/cmd/cie/status.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -126,16 +125,10 @@ Output Fields:
 	}
 
 	// Determine data directory
-	homeDir, err := os.UserHomeDir()
+	dataDir, err := projectDataDir(cfg, configPath)
 	if err != nil {
-		errors.FatalError(errors.NewInternalError(
-			"Cannot determine home directory",
-			"Operating system failed to provide user home directory path",
-			"Check your system configuration or set the HOME environment variable",
-			err,
-		), globals.JSON)
+		errors.FatalError(err, globals.JSON)
 	}
-	dataDir := filepath.Join(homeDir, ".cie", "data", cfg.ProjectID)
 
 	result := &StatusResult{
 		ProjectID: cfg.ProjectID,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,7 @@ indexing:                    # Indexing behavior
   parser_mode: "..."
   batch_target: 500
   max_file_size: 1048576
+  local_data_dir: "~/.cie/data"
   exclude: [...]
 
 roles:                       # Custom role patterns (optional)
@@ -360,6 +361,24 @@ indexing:
 
 **Performance note:** Larger files take longer to parse and generate more embeddings. If indexing is slow, consider lowering this value.
 
+#### indexing.local_data_dir
+
+- **Type:** `string`
+- **Required:** No
+- **Default:** `~/.cie/data`
+- **Environment Override:** `CIE_DATA_DIR`
+- **Description:** Root directory for local embedded data. CIE appends `/<project_id>` automatically.
+
+**Path resolution:**
+- Absolute paths are used as-is
+- Relative paths are resolved from the directory containing `.cie/project.yaml`
+
+**Example:**
+```yaml
+indexing:
+  local_data_dir: "/mnt/cie-data"
+```
+
 #### indexing.exclude
 
 - **Type:** `array of strings`
@@ -564,6 +583,7 @@ Environment variables override configuration file values. Use them for:
 | `CIE_PROJECT_ID` | `string` | from config | Override project ID |
 | `CIE_PRIMARY_HUB` | `string` | `localhost:50051` | Primary Hub gRPC address |
 | `CIE_BASE_URL` | `string` | `""` (empty) | Edge Cache HTTP URL (remote mode only) |
+| `CIE_DATA_DIR` | `string` | `~/.cie/data` | Override local embedded data root (`/<project_id>` is appended) |
 | `CIE_LLM_URL` | `string` | — | Enable LLM, set base URL |
 | `CIE_LLM_MODEL` | `string` | — | LLM model name |
 | `CIE_LLM_API_KEY` | `string` | — | LLM API key |
@@ -1202,13 +1222,13 @@ indexing:
 
 ### Storage Settings
 
-CIE stores data in `~/.cie/data/<project_id>/` (embedded mode) or connects to remote servers.
+CIE stores data in `<local_data_dir>/<project_id>/` (embedded mode) or connects to remote servers.
+By default, `local_data_dir` is `~/.cie/data`.
 
 **Local storage:**
 ```
-~/.cie/
-└── data/
-    └── <project_id>/        # CozoDB database files
+<local_data_dir>/
+└── <project_id>/            # CozoDB database files
         ├── cozo_data.db
         └── cozo_wal.db
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,7 +85,7 @@ cie index
 ```
 
 **What happens:**
-- CIE parses your code locally using Tree-sitter and stores the index in `~/.cie/data/<project>/`.
+- CIE parses your code locally using Tree-sitter and stores the index in `<local_data_dir>/<project>` (default: `~/.cie/data/<project>`).
 - Functions, types, and call graphs are extracted and stored.
 
 > **Note:** Ollama is optional. Without it, CIE indexes all metadata (functions, types, calls) but skips embeddings. 20+ tools work without embeddings; semantic search requires them.
@@ -164,7 +164,7 @@ cie serve --port 9090
 ```
 
 This starts a local HTTP server that:
-- Uses your local indexed data from `~/.cie/data/<project_id>/`
+- Uses your local indexed data from `<local_data_dir>/<project_id>/` (default: `~/.cie/data/<project_id>/`)
 - Exposes a REST API for querying the index
 
 However, `cie --mcp` now works directly in embedded mode -- no server needed. For most users, the MCP integration is the recommended way to connect CIE to AI assistants.

--- a/pkg/cozodb/cozodb.go
+++ b/pkg/cozodb/cozodb.go
@@ -24,8 +24,9 @@ package cozodb
 #include <string.h>
 #include "cozo_c.h"
 
-// CGO flags for linking - these are overridden by environment variables
-#cgo LDFLAGS: -lcozo_c -lstdc++ -lm
+// CGO flags for linking.
+// Use ${SRCDIR} so "go install ./cmd/cie" can find the vendored static library in ./lib.
+#cgo LDFLAGS: -L${SRCDIR}/../../lib -lcozo_c -lstdc++ -lm
 #cgo windows LDFLAGS: -lbcrypt -lwsock32 -lws2_32 -lshlwapi -lrpcrt4
 #cgo darwin LDFLAGS: -framework Security
 */

--- a/pkg/ingestion/local_pipeline.go
+++ b/pkg/ingestion/local_pipeline.go
@@ -218,6 +218,26 @@ func NewLocalPipeline(config Config, logger *slog.Logger) (*LocalPipeline, error
 	}, nil
 }
 
+// FunctionCount returns the number of functions currently indexed in the database.
+func (p *LocalPipeline) FunctionCount() int {
+	if p.backend == nil {
+		return 0
+	}
+	result, err := p.backend.Query(context.Background(), "?[count(id)] := *cie_function{id}")
+	if err != nil || len(result.Rows) == 0 {
+		return 0
+	}
+	if row := result.Rows[0]; len(row) > 0 {
+		if v, ok := row[0].(float64); ok {
+			return int(v)
+		}
+		if v, ok := row[0].(int); ok {
+			return v
+		}
+	}
+	return 0
+}
+
 // Close cleans up resources.
 func (p *LocalPipeline) Close() error {
 	var lastErr error


### PR DESCRIPTION
## Description

Add support for a configurable local data directory, replacing the hardcoded `~/.cie/data/` path. Users can now control where CIE stores indexed data via the `indexing.local_data_dir` config field or the `CIE_DATA_DIR` environment variable. Relative paths are resolved from the directory containing `.cie/project.yaml`.

Additionally includes stale RocksDB LOCK file recovery (auto-removes orphaned locks from crashed processes), graceful shutdown improvements, and build system fixes.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] CI/CD or build changes

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests that prove my fix/feature works
- [x] New and existing tests pass locally with my changes

### Tests added
- `cmd/cie/paths_test.go` — unit tests for `projectDataDir`, `dataRootFromConfig`, path resolution (absolute, relative, default fallback)
- `pkg/storage/embedded_test.go` — `TestIsStaleLock_NoLockFile`, `TestIsStaleLock_StaleLock`, `TestIsStaleLock_ActiveLock`

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make fmt` and `make lint`
- [x] I have added comments for complex code sections
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Key Changes

### Configurable data directory
| Method | Example | Behavior |
|--------|---------|----------|
| Config field | `indexing.local_data_dir: "/mnt/cie-data"` | Absolute path used as-is, `/<project_id>` appended |
| Config field (relative) | `indexing.local_data_dir: ".cie-data"` | Resolved from project config directory |
| Env var | `CIE_DATA_DIR=/mnt/cie-data` | Overrides config field |
| Default | _(unset)_ | `~/.cie/data/<project_id>/` (unchanged behavior) |

### Legacy data migration warning
When `local_data_dir` is configured and data exists at the old default path (`~/.cie/data/<project_id>/`) but not at the new path, CIE prints a warning guiding the user to re-index.

### Stale RocksDB LOCK recovery (`pkg/storage/embedded.go`)
If CozoDB fails to open and a `LOCK` file exists, CIE checks whether any process actually holds the `flock`. If not (crashed/killed process), it removes the stale lock and retries. This eliminates the need for users to manually delete lock files after crashes.

### Graceful shutdown improvements
- All signal handlers now call `signal.Stop(sigChan)` so a second Ctrl+C force-quits immediately
- User-facing message: `"Shutting down... Press Ctrl+C again to force quit."`
- Applied to: `index`, `mcp`, and `serve` commands

### Build fixes (`Makefile`, `pkg/cozodb/cozodb.go`)
- `INSTALL_DIR` uses `$(GOPATH)/bin` instead of `$(HOME)/go/bin`
- macOS: ad-hoc codesign after install (`codesign --force --sign -`)
- CGO LDFLAGS: `-L${SRCDIR}/../../lib` so `go install ./cmd/cie` finds the vendored static library

### Refactoring
- Centralized path resolution in new `cmd/cie/paths.go` (replaces scattered `filepath.Join(homeDir, ".cie", "data", ...)` calls)
- Moved `checkLocalData` logic into `LocalPipeline.FunctionCount()` — queries through the already-open DB instead of opening a second connection
- `storage.EmbeddedConfig.DataDir` is now passed explicitly instead of being computed internally

## Additional Notes

- **Backward compatible**: when `local_data_dir` is not set, behavior is identical to before
- The `EmbeddedConfig.DataDir` field replaces the internal `~/.cie/data/<project>` computation in `storage.NewEmbeddedBackend`, giving callers full control over the path
