### PR TITLE
fix(index): honor llamacpp provider and show underlying error details

### DIFF
--- a/cmd/cie/index.go
+++ b/cmd/cie/index.go
@@ -267,6 +267,8 @@ func runLocalIndex(ctx context.Context, logger *slog.Logger, cfg *Config, config
 		if cfg.Embedding.APIKey != "" {
 			_ = os.Setenv("OPENAI_API_KEY", cfg.Embedding.APIKey)
 		}
+	case "llamacpp", "qodo":
+		_ = os.Setenv("LLAMACPP_EMBED_URL", cfg.Embedding.BaseURL)
 	}
 
 	pipeline, err := ingestion.NewLocalPipeline(config, logger)
@@ -367,8 +369,12 @@ func mapEmbeddingProvider(provider string) string {
 		return "openai"
 	case "mock":
 		return "mock"
+	case "llamacpp", "qodo":
+		return provider
 	default:
-		return "mock"
+		// Preserve unknown values so CreateEmbeddingProvider can return a clear error
+		// instead of silently falling back to mock.
+		return provider
 	}
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -355,6 +355,12 @@ func (e *UserError) Format(noColor bool) string {
 		out.WriteString("\n")
 	}
 
+	if e.Err != nil {
+		out.WriteString("Details: ")
+		out.WriteString(e.Err.Error())
+		out.WriteString("\n")
+	}
+
 	return out.String()
 }
 


### PR DESCRIPTION
Unrelated: you have a mac library committed in there, `lib/libcozo_c.a`

 This PR fixes two issues in cie index:

 1. embedding.provider: llamacpp was not honored by CLI mapping
     - cmd/cie/index.go only mapped a limited set of providers and silently fell back to mock for unknown values.
     - As a result, valid llamacpp config could be downgraded to mock at runtime.
 2. Underlying error details were hidden in CLI output
     - internal/errors.UserError.Format() printed only high-level message/cause/fix.
     - Wrapped/root errors were not shown, making troubleshooting difficult.

 What changed

 ### cmd/cie/index.go

 - Updated provider mapping to explicitly support:
     - llamacpp
     - qodo
 - Changed default behavior to preserve unknown provider strings so provider validation happens in the embedding layer (instead of
 silent fallback to mock).
 - Added llama.cpp env wiring:
     - LLAMACPP_EMBED_URL now populated from config embedding.base_url.

 ### internal/errors/errors.go

 - UserError.Format() now appends:
     - Details: <underlying error>
 - This surfaces wrapped exceptions directly in CLI output.